### PR TITLE
Fix/#7 `LinkServiceTest` 검증 로직 오류 수정

### DIFF
--- a/backend/project2/src/test/java/com/team8/project2/domain/link/service/LinkServiceTest.java
+++ b/backend/project2/src/test/java/com/team8/project2/domain/link/service/LinkServiceTest.java
@@ -1,10 +1,11 @@
 package com.team8.project2.domain.link.service;
 
-import com.team8.project2.domain.link.dto.LinkReqDTO;
-import com.team8.project2.domain.link.entity.Link;
-import com.team8.project2.domain.link.repository.LinkRepository;
-import com.team8.project2.global.exception.ServiceException;
-import jakarta.servlet.http.HttpServletRequest;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,11 +16,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-import java.time.Duration;
-import java.util.Optional;
+import com.team8.project2.domain.link.dto.LinkReqDTO;
+import com.team8.project2.domain.link.entity.Link;
+import com.team8.project2.domain.link.repository.LinkRepository;
+import com.team8.project2.global.exception.ServiceException;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import jakarta.servlet.http.HttpServletRequest;
 
 @ExtendWith(MockitoExtension.class)
 class LinkServiceTest {
@@ -32,9 +34,11 @@ class LinkServiceTest {
     @Mock
     private HttpServletRequest request;
 
+    @Mock
+    private LinkClickService linkClickService;
+
     @InjectMocks
     private LinkService linkService;
-
 
     private Link link;
 
@@ -177,10 +181,6 @@ class LinkServiceTest {
 
         // 링크 클릭 로직이 제대로 동작하도록 설정
         when(linkRepository.findById(1L)).thenReturn(Optional.of(link));
-        when(linkRepository.save(any(Link.class))).thenReturn(link);
-
-        // 클릭수 초기 상태 저장
-        int initialClickCount = link.getClick();
 
         // When: 링크를 여러 번 클릭한다
         linkService.getLinkAndIncrementClick(1L, request);  // 첫 번째 클릭
@@ -188,7 +188,7 @@ class LinkServiceTest {
         linkService.getLinkAndIncrementClick(1L, request);  // 세 번째 클릭
 
         // Then: 클릭수는 한 번만 증가해야 한다
-        assertEquals(initialClickCount + 1, link.getClick()); // 클릭수가 1만 증가해야 한다.
+        verify(linkClickService, times(1)).increaseClickCount(any()); // 클릭수가 1만 증가해야 한다.
     }
 
     // 이미 클릭한 사용자에 대해 클릭수 증가하지 않는 테스트
@@ -239,5 +239,4 @@ class LinkServiceTest {
         assertEquals("404-1", exception.getCode());
         assertEquals("해당 링크를 찾을 수 없습니다.", exception.getMessage());
     }
-
 }


### PR DESCRIPTION
## 개요
`LinkServiceTest`에서 검증 로직 오류로 실패하던 `이미 클릭한 경우 클릭수가 증가하지 않아야 한다` 테스트 수정.

추가로 현재 `LinkServiceTest`는 `LinkService`의 단위 테스트임에도 실제로 Redis를 사용하고 있는데, 이에 대해서 논의가 필요해 보임

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<img width="361" alt="image" src="https://github.com/user-attachments/assets/7b204780-1eb7-437b-b3f3-9b437bfeefd6" />

Closes #7 
