### PR TITLE
Feat/#14 `ApiV1CurationControllerTest` 누락된 테스트 작성

### DIFF
--- a/backend/project2/src/main/java/com/team8/project2/domain/playlist/repository/PlaylistItemRepository.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/playlist/repository/PlaylistItemRepository.java
@@ -1,0 +1,10 @@
+package com.team8.project2.domain.playlist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.team8.project2.domain.playlist.entity.PlaylistItem;
+
+@Repository
+public interface PlaylistItemRepository extends JpaRepository<PlaylistItem, Long> {
+}

--- a/backend/project2/src/main/java/com/team8/project2/global/init/BaseInitData.java
+++ b/backend/project2/src/main/java/com/team8/project2/global/init/BaseInitData.java
@@ -237,7 +237,7 @@ public class BaseInitData {
 					.build();
 
 			PlaylistDto playlistDto = playlistService.createPlaylist(playlistCreateDto, member);
-			Playlist playList = playlistRepository.findById(playlistDto.getId()).get();
+			Playlist playlist = playlistRepository.findById(playlistDto.getId()).get();
 
 			// 플레이리스트에 큐레이션(1L) 추가
 			Curation curation = curationRepository.findById(1L).get();
@@ -245,7 +245,7 @@ public class BaseInitData {
 				.itemId(1L)
 				.curation(curation)
 				.itemType(PlaylistItem.PlaylistItemType.CURATION)
-				.playlist(playList)
+				.playlist(playlist)
 				.displayOrder(0)
 				.build();
 			playlistItemRepository.save(newItem);

--- a/backend/project2/src/main/java/com/team8/project2/global/init/BaseInitData.java
+++ b/backend/project2/src/main/java/com/team8/project2/global/init/BaseInitData.java
@@ -1,5 +1,13 @@
 package com.team8.project2.global.init;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import com.team8.project2.domain.comment.dto.CommentDto;
 import com.team8.project2.domain.comment.service.CommentService;
 import com.team8.project2.domain.curation.curation.entity.Curation;
@@ -12,15 +20,14 @@ import com.team8.project2.domain.member.entity.RoleEnum;
 import com.team8.project2.domain.member.repository.FollowRepository;
 import com.team8.project2.domain.member.repository.MemberRepository;
 import com.team8.project2.domain.playlist.dto.PlaylistCreateDto;
+import com.team8.project2.domain.playlist.dto.PlaylistDto;
+import com.team8.project2.domain.playlist.entity.Playlist;
+import com.team8.project2.domain.playlist.entity.PlaylistItem;
+import com.team8.project2.domain.playlist.repository.PlaylistItemRepository;
+import com.team8.project2.domain.playlist.repository.PlaylistRepository;
 import com.team8.project2.domain.playlist.service.PlaylistService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.boot.ApplicationRunner;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
@@ -28,8 +35,10 @@ public class BaseInitData {
 
 	private final MemberRepository memberRepository;
 	private final CurationRepository curationRepository;
+	private final PlaylistRepository playlistRepository;
 	private final CurationService curationService;
 	private final S3Uploader s3Uploader;
+	private final PlaylistItemRepository playlistItemRepository;
 
 	@Bean
 	public ApplicationRunner init(CommentService commentService, FollowRepository followRepository, PlaylistService playlistService) {
@@ -227,10 +236,19 @@ public class BaseInitData {
 					.isPublic(true)
 					.build();
 
-			playlistService.createPlaylist(playlistCreateDto, member);
-			System.out.println("✅ " + member.getUsername() + "이(가) 플레이리스트 생성: " + playlistTitles[i]);
+			PlaylistDto playlistDto = playlistService.createPlaylist(playlistCreateDto, member);
+			Playlist playList = playlistRepository.findById(playlistDto.getId()).get();
+
+			// 플레이리스트에 큐레이션(1L) 추가
+			Curation curation = curationRepository.findById(1L).get();
+			PlaylistItem newItem = PlaylistItem.builder()
+				.itemId(1L)
+				.curation(curation)
+				.itemType(PlaylistItem.PlaylistItemType.CURATION)
+				.playlist(playList)
+				.displayOrder(0)
+				.build();
+			playlistItemRepository.save(newItem);
 		}
 	}
-
-
 }


### PR DESCRIPTION
## 개요
`ApiV1CurationControllerTest`에 아래 테스트들을 추가했습니다.
- 특정 큐레이션을 포함하고 있는 자신의 플레이리스트 목록을 조회할 수 있다
- 트렌딩 태그를 조회할 수 있다
- 트렌딩 큐레이션을 조회할 수 있다
- 특정 큐레이션에 대해 자신이 좋아요를 눌렀는지 확인할 수 있다

트렌딩 태그, 트렌딩 큐레이션 테스트에 한계가 있음
(실제 조회수 기반 동작을 확인하려면 Redis 조회수 추가 해야 가능)

플레이리스트 목록 조회 테스트를 위해 `BaseInitData`에서 플레이리스트를 생성할 때
큐레이션이 플레이리스트에 추가되도록 수정했습니다.
(모든 플레이리스트들이 id=1인 큐레이션을 가진 상태로 초기화됨)

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<img width="480" alt="스크린샷 2025-04-05 오후 4 45 24" src="https://github.com/user-attachments/assets/00eda6df-9a75-40b5-9b54-52faa2a8a67e" />

Closed #14 
