### PR TITLE
refactor: Member id를 val로 변경, null 검증을 Repository로 위임

### DIFF
--- a/backend/project2/src/main/java/com/team8/project2/domain/admin/controller/ApiV1AdminController.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/admin/controller/ApiV1AdminController.kt
@@ -41,12 +41,7 @@ class ApiV1AdminController(
     @DeleteMapping("/members/{memberId}")
     fun deleteMember(@PathVariable memberId: Long): RsData<Unit> {
         val member = memberService.findById(memberId)
-            .orElseThrow {
-                ServiceException(
-                    "404-1",
-                    "해당 회원을 찾을 수 없습니다."
-                )
-            }
+
         adminService.deleteMember(member)
         return RsData.success("멤버가 삭제되었습니다.")
     }

--- a/backend/project2/src/main/java/com/team8/project2/domain/comment/controller/ApiV1GlobalCommentController.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/comment/controller/ApiV1GlobalCommentController.kt
@@ -30,9 +30,8 @@ class ApiV1GlobalCommentController(
     fun getCommentsByCurationId(): RsData<List<CommentDto>> {
         val author = rq.actor
         val member = memberService.findById(author.id)
-            .orElseThrow { ServiceException("404-1", "해당 회원을 찾을 수 없습니다.") }
 
-        val commentDtos = commentService.findAllByAuthorId(member.id)
+        val commentDtos = commentService.findAllByAuthorId(member.id!!)
         return RsData.success("내 댓글 조회 성공", commentDtos)
     }
 

--- a/backend/project2/src/main/java/com/team8/project2/domain/comment/dto/ReplyCommentDto.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/comment/dto/ReplyCommentDto.kt
@@ -35,7 +35,7 @@ data class ReplyCommentDto(
         fun fromEntity(reply: ReplyComment): ReplyCommentDto {
             return ReplyCommentDto(
                 id = reply.id,
-                authorId = reply.author.id,
+                authorId = reply.author.id!!,
                 authorName = reply.author.getUsername(),
                 authorProfileImageUrl = reply.author.profileImage.toString(),
                 content = reply.content,

--- a/backend/project2/src/main/java/com/team8/project2/domain/comment/entity/Comment.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/comment/entity/Comment.kt
@@ -72,7 +72,7 @@ class Comment(
 
     fun getAuthorName(): String = author.getUsername()
 
-    fun getAuthorId(): Long = author.id
+    fun getAuthorId(): Long = author.id!!
 
     fun getAuthorImgUrl(): String = author.profileImage.toString()
 

--- a/backend/project2/src/main/java/com/team8/project2/domain/comment/entity/ReplyComment.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/comment/entity/ReplyComment.kt
@@ -75,5 +75,5 @@ class ReplyComment(
         this.content = content
     }
 
-    fun getAuthorId(): Long = author.id
+    fun getAuthorId(): Long = author.id!!
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.kt
@@ -150,7 +150,7 @@ class ApiV1CurationController(
     @PreAuthorize("isAuthenticated()")
     fun likeCuration(@PathVariable id: Long): RsData<Void?> {
         val memberId = rq.actor.id
-        curationService.likeCuration(id, memberId)
+        curationService.likeCuration(id, memberId!!)
         return RsData("200-1", "글에 좋아요를 했습니다.", null)
     }
 
@@ -163,7 +163,7 @@ class ApiV1CurationController(
     @GetMapping("/like/{id}/status")
     fun isCurationLiked(@PathVariable id: Long): RsData<Boolean> {
         val memberId = rq.actor.id
-        val isLiked = curationService.isLikedByMember(id, memberId)
+        val isLiked = curationService.isLikedByMember(id, memberId!!)
         return RsData("200-1", "좋아요 여부 확인 성공", isLiked)
     }
 

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/entity/Curation.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/entity/Curation.kt
@@ -106,7 +106,7 @@ class Curation(
         get() = member.getUsername()
 
     val memberId: Long
-        get() = member.id
+        get() = member.id!!
 
     val memberImgUrl: String?
         get() = member.profileImage

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/service/CurationService.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/service/CurationService.kt
@@ -231,7 +231,6 @@ class CurationService(
         // 삭제 권한이 있는지 확인 (작성자와 요청자가 같은지 확인)
         println("어드민이야?" + member.isAdmin)
         println("어드민이야?" + curation.member!!.id)
-        println("어드민이야?" + member.getMemberId())
         if (curation.member!!.id != member.id && !member.isAdmin) {
             throw ServiceException("403-1", "권한이 없습니다.") // 권한 없음
         }
@@ -327,7 +326,7 @@ class CurationService(
         if (rq.isLogin) {
             isLogin = true
             val actor = rq.actor
-            isLiked = isLikedByMember(curationId, actor.id)
+            isLiked = isLikedByMember(curationId, actor.id!!)
             isFollowed = memberService.isFollowed(curation.memberId, actor.id)
         }
 
@@ -484,7 +483,7 @@ class CurationService(
      */
     fun getFollowingCurations(member: Member, page: Int, size: Int): List<CurationResDto> {
         val pageable: Pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
-        val followingCurations = curationRepository.findFollowingCurations(member.id, pageable)
+        val followingCurations = curationRepository.findFollowingCurations(member.id!!, pageable)
         return followingCurations.stream()
             .map { curation: Curation -> CurationResDto.from(curation) }
             .collect(Collectors.toList())

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/report/controller/ApiV1ReportController.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/report/controller/ApiV1ReportController.kt
@@ -25,12 +25,11 @@ class ApiV1ReportController(
     fun getReports(@PathVariable memberId: Long): RsData<List<ReportDto>> {
         val member = rq.actor
 
-        if (!member.id.equals(memberId)) {
+        if (!member.id!!.equals(memberId)) {
             throw ServiceException("403-1", "회원 정보가 일치하지 않습니다.")
         }
 
         val reporter = memberService.findById(memberId)
-            .orElseThrow { ServiceException("404-1", "해당 회원을 찾을 수 없습니다.") }
 
         val reports = reportService.findAllByReporter(reporter)
         return RsData("200-1", "글이 성공적으로 조회되었습니다.", reports)

--- a/backend/project2/src/main/java/com/team8/project2/domain/member/dto/MemberResDTO.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/member/dto/MemberResDTO.kt
@@ -3,6 +3,7 @@ package com.team8.project2.domain.member.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.team8.project2.domain.member.entity.Member
 import com.team8.project2.domain.member.entity.RoleEnum
+import com.team8.project2.global.exception.ServiceException
 import lombok.Data
 import java.time.LocalDateTime
 
@@ -38,7 +39,7 @@ data class MemberResDTO(
         @JvmStatic
         fun fromEntity(member: Member): MemberResDTO {
             return MemberResDTO(
-                id = member.id,
+                id = member.id?: throw ServiceException("400-1", "ID는 null일 수 없습니다."),
                 memberId = member.getMemberId(),
                 username = member.getUsername(),
                 email = member.email,

--- a/backend/project2/src/main/java/com/team8/project2/domain/member/entity/Member.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/member/entity/Member.kt
@@ -9,14 +9,34 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import java.time.LocalDateTime
 
 @Entity
-@EntityListeners(
-    AuditingEntityListener::class
-)
-class Member() {
+@EntityListeners(AuditingEntityListener::class)
+class Member(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    var id: Long = 0L
+    val id: Long? = null,
+
+    @Column(length = 100, unique = true)
+    private var memberId: String? = null,
+
+    @Column(nullable = false)
+    private var password: String? = null,
+
+    @Column(length = 100, unique = true)
+    private var username: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var role: RoleEnum = RoleEnum.MEMBER,
+
+    @Column
+    var profileImage: String? = null,
+
+    @Column
+    var email: String? = null,
+
+    @Column
+    var introduce: String? = null
+) {
 
     @CreatedDate
     var createdDate: LocalDateTime? = null
@@ -24,168 +44,30 @@ class Member() {
     @LastModifiedDate
     var modifiedDate: LocalDateTime? = null
 
-    @Column(length = 100, unique = true)
-    private var memberId: String? = null
+    init {
+        // 예: username이 null이면 "anonymous" 할당
+        if (username == null) {
+            username = "anonymous"
+        }
+    }
 
-    @Column(nullable = false)
-    private var password: String? = null
-
-    @Column(length = 100, unique = true, nullable = true)
-    private var username: String? = null
-
-    //username null시 annoymous 할당
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false) //@Builder.Default
-    var role = RoleEnum.MEMBER
-
-    @Column
-    var profileImage: String? = null
-
-    @Column
-    var email: String? = null
-
-    @Column
-    var introduce: String? = null
-
-    //생성자
-
-
-    constructor(
-        memberId: String,
-        username: String?,
-        password: String?,
-        role: RoleEnum?,
-        profileImage: String?,
-        email: String?,
-        introduce: String?
-    ) : this() {
-        this.memberId = memberId
+    // getter 예시
+    fun getMemberId(): String = memberId ?: throw UninitializedPropertyAccessException("memberId is not initialized")
+    fun getUsername(): String = username ?: throw UninitializedPropertyAccessException("username is not initialized")
+    fun getPassword(): String = password ?: throw UninitializedPropertyAccessException("password is not initialized")
+    fun setUsername(username: String) {
         this.username = username
-        this.password = password
-        this.role = role ?: RoleEnum.MEMBER
-        this.profileImage = profileImage
-        this.email = email
-        this.introduce = introduce
     }
 
-    // Test 용 생성자
-    constructor(id: Long, memberId: String) : this() {
-        this.id = id
-        this.memberId = memberId
-        this.password = "blank"
-        this.username = "default"
-    }
-    constructor(
-        memberId: String,
-        password: String?,
-        role: RoleEnum,
-        email: String?,
-        profileImage: String?,
-        introduce: String?
-    ) : this() {
-        this.memberId = memberId
-        this.password = password
-        this.role = role
-        this.email = email
-        this.profileImage = profileImage
-        this.introduce = introduce
-    }
+    // 상태
+    val isAdmin: Boolean get() = this.role == RoleEnum.ADMIN
+    val isMember: Boolean get() = this.role == RoleEnum.MEMBER
 
-    constructor(id: Long, username: String, email: String) : this() {
-        this.id = id
-        this.username = username
-        this.email = email
-        this.password = "blank"
-        this.memberId = "0"
-    }
-
-    constructor(memberId: String) : this() {
-        this.memberId = memberId
-        this.password = "blank"
-        this.username = "default"
-        this.username = "default"
-    }
-
-    constructor(id: Long) : this() {
-        this.id = id
-        this.password = "blank"
-        this.username = "default"
-    }
-
-    constructor(
-        id: Long,
-        username: String,
-        password: String,
-        role: RoleEnum
-    ) : this() {
-        this.id = id
-        this.username = username
-        this.password = password
-        this.role = role
-        this.memberId = "default" // 또는 UUID 생성 등
-    }
-
-    constructor(
-        id: Long,
-        memberId: String,
-        username: String?,
-        password: String?,
-        role: RoleEnum?,
-        email: String?,
-        profileImage: String?,
-        introduce: String?
-    ) : this() {
-        this.id = id
-        this.memberId = memberId
-        this.username = username
-        this.password = password
-        this.role = role ?: RoleEnum.MEMBER
-        this.email = email
-        this.profileImage = profileImage
-        this.introduce = introduce
-    }
-
-
-    //getter
-    fun getMemberId(): String {
-        return memberId ?: throw UninitializedPropertyAccessException("memberId is not initialized")
-    }
-    fun getUsername(): String {
-        return username ?: throw UninitializedPropertyAccessException("username is not initialized")
-    }
-    fun getPassword(): String {
-        return password ?: throw UninitializedPropertyAccessException("password is not initialized")
-    }
-    // setter
-    fun setUsername(newName: String) {
-        this.username = newName
-    }
-
-    // 상태 체크
-    val isAdmin: Boolean
-        get() = this.role == RoleEnum.ADMIN
-    val isMember: Boolean
-        get() = this.role == RoleEnum.MEMBER
-
-    val authorities: Collection<GrantedAuthority?>
-        get() = memberAuthoritesAsString
-            .stream()
-            .map { role: String? ->
-                SimpleGrantedAuthority(
-                    role
-                )
-            }
-            .toList()
+    val authorities: Collection<GrantedAuthority>
+        get() = memberAuthoritesAsString.map { SimpleGrantedAuthority(it) }
 
     val memberAuthoritesAsString: List<String>
-        get() {
-            val authorities: MutableList<String> = ArrayList()
-
-            if (isAdmin) {
-                authorities.add("ROLE_ADMIN")
-            }
-
-            return authorities
+        get() = buildList {
+            if (isAdmin) add("ROLE_ADMIN")
         }
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/member/repository/MemberRepository.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/member/repository/MemberRepository.kt
@@ -1,6 +1,7 @@
 package com.team8.project2.domain.member.repository
 
 import com.team8.project2.domain.member.entity.Member
+import com.team8.project2.global.exception.ServiceException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository

--- a/backend/project2/src/main/java/com/team8/project2/domain/member/repository/MemberRepositoryExtensions.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/member/repository/MemberRepositoryExtensions.kt
@@ -1,0 +1,15 @@
+package com.team8.project2.domain.member.repository
+
+import com.team8.project2.domain.member.entity.Member
+import com.team8.project2.global.exception.ServiceException
+
+fun MemberRepository.findByIdOrThrow(id: Long?): Member {
+    return id?.let {
+        this.findByIdOrNull(it)
+            ?: throw ServiceException("404-1", "해당 회원을 찾을 수 없습니다.")
+    } ?: throw ServiceException("400-1", "ID는 null일 수 없습니다.")
+}
+
+fun MemberRepository.findByIdOrNull(id: Long?): Member? {
+    return id?.let { this.findById(it).orElse(null) }
+}

--- a/backend/project2/src/main/java/com/team8/project2/domain/member/service/MemberService.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/member/service/MemberService.kt
@@ -12,6 +12,7 @@ import com.team8.project2.domain.member.entity.RoleEnum
 import com.team8.project2.domain.member.event.ProfileImageUpdateEvent
 import com.team8.project2.domain.member.repository.FollowRepository
 import com.team8.project2.domain.member.repository.MemberRepository
+import com.team8.project2.domain.member.repository.findByIdOrThrow
 import com.team8.project2.global.Rq
 import com.team8.project2.global.exception.ServiceException
 import org.springframework.context.ApplicationEventPublisher
@@ -50,12 +51,12 @@ class MemberService(
             role = RoleEnum.MEMBER
         }
         val member = Member(
-            memberId!!,
-            password,
-            RoleEnum.MEMBER,  // 기본값 지정이 사라졌을 수 있으므로 명시
-            email,
-            profileImage,
-            introduce
+            memberId = memberId,
+            password = password,
+            role = RoleEnum.MEMBER,  // 기본값 지정이 사라졌을 수 있으므로 명시
+            email = email,
+            profileImage = profileImage,
+            introduce = introduce
         )
         return memberRepository.save(member)
     }
@@ -73,8 +74,8 @@ class MemberService(
         return memberRepository.findByUsername(username)
     }
 
-    fun findById(id: Long): Optional<Member> {
-        return memberRepository.findById(id)
+    fun findById(id: Long?): Member {
+        return memberRepository.findByIdOrThrow(id)
     }
 
     fun getAuthToken(member: Member?): String {
@@ -170,7 +171,7 @@ class MemberService(
         if (rq.isLogin) {
             isLogin = true
             val actor = rq.actor
-            isFollowed = followRepository.existsByFollowerIdAndFolloweeId(actor.id, member.id)
+            isFollowed = followRepository.existsByFollowerIdAndFolloweeId(actor.id!!, member.id!!)
         }
 
         return CuratorInfoDto(

--- a/backend/project2/src/main/java/com/team8/project2/domain/playlist/controller/ApiV1PlaylistController.kt
+++ b/backend/project2/src/main/java/com/team8/project2/domain/playlist/controller/ApiV1PlaylistController.kt
@@ -163,7 +163,7 @@ class ApiV1PlaylistController(
     @PostMapping("/{id}/like")
     fun likePlaylist(@PathVariable id: Long): RsData<Unit> {
         val memberId = rq.actor.id
-        playlistService.likePlaylist(id, memberId)
+        playlistService.likePlaylist(id, memberId!!)
         return success("좋아요 상태가 토글되었습니다.", Unit)
     }
 
@@ -179,7 +179,7 @@ class ApiV1PlaylistController(
             return success("비로그인 상태입니다.", false)
         }
         val memberId = rq.actor.id
-        val liked = playlistService.hasLikedPlaylist(id, memberId)
+        val liked = playlistService.hasLikedPlaylist(id, memberId!!)
         return success("좋아요 상태 조회 성공", liked)
     }
 
@@ -242,7 +242,7 @@ class ApiV1PlaylistController(
     @GetMapping("/liked")
     fun getLikedPlaylists(): RsData<List<PlaylistDto>> {
         val memberId = rq.actor.id
-        val likedPlaylists = playlistService.getLikedPlaylistsFromRedis(memberId)
+        val likedPlaylists = playlistService.getLikedPlaylistsFromRedis(memberId!!)
         return success("좋아요한 플레이리스트 조회 성공", likedPlaylists)
     }
 

--- a/backend/project2/src/main/java/com/team8/project2/global/Rq.kt
+++ b/backend/project2/src/main/java/com/team8/project2/global/Rq.kt
@@ -33,7 +33,7 @@ class Rq(
     fun getAuthentication(member: Member): Authentication {
         val userDetails: UserDetails =
             SecurityUser(
-                member.id,
+                member.id!!,
                 member.getMemberId(),
                 "",
                 member.authorities,
@@ -65,7 +65,6 @@ class Rq(
 
             return memberService
                 .findById(principal.id)
-                .orElseThrow { ServiceException("404-1", "사용자를 찾을 수 없습니다.") }
         }
 
     val isLogin: Boolean
@@ -108,7 +107,6 @@ class Rq(
     fun getRealActor(actor: Member): Member =
         memberService
             .findById(actor.id)
-            .orElseThrow { ServiceException("404-1", "사용자를 찾을 수 없습니다.") }
 
     fun removeCookie(name: String) {
         val cookie =

--- a/backend/project2/src/main/java/com/team8/project2/global/init/BaseInitData.kt
+++ b/backend/project2/src/main/java/com/team8/project2/global/init/BaseInitData.kt
@@ -64,13 +64,13 @@ class BaseInitData(
 
     private fun createMember(email: String, username: String, memberId: String, displayName: String, password: String, profileImage: String, introduce: String, role: RoleEnum): Member {
         val member = Member(
-            memberId,
-            displayName,
-            password,
-            role,
-            profileImage,
-            email,
-            introduce
+            memberId = memberId,
+            username = displayName,
+            password = password,
+            role = role,
+            profileImage = profileImage,
+            email = email,
+            introduce = introduce
         )
 
         return memberRepository.save(member)

--- a/backend/project2/src/main/java/com/team8/project2/global/security/CustomUserDetailService.kt
+++ b/backend/project2/src/main/java/com/team8/project2/global/security/CustomUserDetailService.kt
@@ -15,7 +15,7 @@ class CustomUserDetailService(
             ?: throw UsernameNotFoundException("사용자를 찾을 수 없습니다.")
 
         return SecurityUser(
-            id = member.id,
+            id = member.id!!,
             username = member.getMemberId(),
             password = member.getPassword(),
             authorities = member.authorities,

--- a/backend/project2/src/test/java/com/team8/project2/domain/member/controller/ApiV1MemberControllerTest.kt
+++ b/backend/project2/src/test/java/com/team8/project2/domain/member/controller/ApiV1MemberControllerTest.kt
@@ -6,6 +6,7 @@ import com.team8.project2.domain.image.service.S3Uploader
 import com.team8.project2.domain.member.dto.MemberReqDTO
 import com.team8.project2.domain.member.entity.RoleEnum
 import com.team8.project2.domain.member.repository.MemberRepository
+import com.team8.project2.domain.member.repository.findByIdOrThrow
 import com.team8.project2.domain.member.service.MemberService
 import com.team8.project2.global.exception.ServiceException
 import org.junit.jupiter.api.DisplayName
@@ -359,8 +360,8 @@ class ApiV1MemberControllerTest @Autowired constructor(
         fun follow() {
             val followeeId = 1L
             val followerId = 2L
-            val followee = memberService.findById(followeeId).get()
-            val member = memberRepository.findById(followerId).get()
+            val followee = memberService.findById(followeeId)
+            val member = memberRepository.findByIdOrThrow(followerId)
             val accessToken = memberService.genAccessToken(member)
 
             mvc.perform(
@@ -384,7 +385,7 @@ class ApiV1MemberControllerTest @Autowired constructor(
         fun follow_alreadyFollowed() {
             val followeeId = 1L
             val followerId = 3L
-            val followee = memberService.findById(followeeId).get()
+            val followee = memberService.findById(followeeId)
             val member = memberRepository.findById(followerId).get()
             val accessToken = memberService.genAccessToken(member)
 
@@ -423,7 +424,7 @@ class ApiV1MemberControllerTest @Autowired constructor(
         fun follow_self() {
             val followeeId = 1L
             val followerId = 1L
-            val followee = memberService.findById(followeeId).get()
+            val followee = memberService.findById(followeeId)
             val member = memberRepository.findById(followerId).get()
             val accessToken = memberService.genAccessToken(member)
 
@@ -442,7 +443,7 @@ class ApiV1MemberControllerTest @Autowired constructor(
         fun unfollow() {
             val followeeId = 1L
             val followerId = 3L
-            val followee = memberService.findById(followeeId).get()
+            val followee = memberService.findById(followeeId)
             val member = memberRepository.findById(followerId).get()
             val accessToken = memberService.genAccessToken(member)
 
@@ -466,7 +467,7 @@ class ApiV1MemberControllerTest @Autowired constructor(
         fun unfollow_notFollowed() {
             val followeeId = 3L
             val followerId = 1L
-            val followee = memberService.findById(followeeId).get()
+            val followee = memberService.findById(followeeId)
             val member = memberRepository.findById(followerId).get()
             val accessToken = memberService.genAccessToken(member)
 
@@ -486,8 +487,8 @@ class ApiV1MemberControllerTest @Autowired constructor(
             val followee1Id = 1L
             val followee2Id = 2L
             val followerId = 3L
-            val followee1 = memberService.findById(followee1Id).get()
-            val followee2 = memberService.findById(followee2Id).get()
+            val followee1 = memberService.findById(followee1Id)
+            val followee2 = memberService.findById(followee2Id)
             val member = memberRepository.findById(followerId).get()
             val accessToken = memberService.genAccessToken(member)
 

--- a/backend/project2/src/test/java/com/team8/project2/domain/member/service/MemberServiceTest.kt
+++ b/backend/project2/src/test/java/com/team8/project2/domain/member/service/MemberServiceTest.kt
@@ -50,15 +50,14 @@ class MemberServiceTest {
     @DisplayName("회원 가입 - null 가능 필드가 모두 채워졌을 때 정상 저장된다.")
     fun join_Succeeds_WhenAllNullableFieldsAreFilled() {
         val member = Member(
-            "fullUser",  // memberId
-            "Full Name",  // username
-            "fullpw",  // password
-            RoleEnum.MEMBER,  // roleEnum
-            "fullImage.png",  // profileImage
-            "full@test.com",  // email
-            "Hello, I'm full user!" // introduce
+            memberId = "fullUser",
+            username = "Full Name",
+            password = "fullpw",
+            role = RoleEnum.MEMBER,
+            profileImage = "fullImage.png",
+            email = "full@test.com",
+            introduce = "Hello, I'm full user!"
         )
-
         whenever(
             memberRepository.save(
                 ArgumentMatchers.any(
@@ -82,13 +81,13 @@ class MemberServiceTest {
     @DisplayName("회원 가입 - null 가능 필드가 모두 비어 있을 때 정상 저장된다.")
     fun join_Succeeds_WhenAllNullableFieldsAreNull() {
         val member = Member(
-            "minimalUser",  // memberId
-            "username", // username
-            "minpw",  // password
-            RoleEnum.MEMBER,  // roleEnum
-            null,  // email
-            null,  // profileImage
-            null // introduce
+            memberId = "minimalUser",
+            username = "username",
+            password = "minpw",
+            role = RoleEnum.MEMBER,
+            profileImage = null,
+            email = null,
+            introduce = null
         )
 
         whenever(
@@ -112,7 +111,7 @@ class MemberServiceTest {
     @DisplayName("회원 삭제 - 존재하는 회원이면 정상적으로 삭제된다.")
     fun deleteMember_Succeeds_WhenMemberExists() {
         // given
-        val member = Member("user1")
+        val member = Member(memberId = "user1")
 
         whenever(memberRepository.findByMemberId("user1")).thenReturn(member)
 

--- a/backend/project2/src/test/java/com/team8/project2/domain/playlist/controller/ApiV1PlaylistControllerTest.kt
+++ b/backend/project2/src/test/java/com/team8/project2/domain/playlist/controller/ApiV1PlaylistControllerTest.kt
@@ -756,7 +756,7 @@ internal class ApiV1PlaylistControllerTest {
             )
         )
 
-        whenever(playlistService.getLikedPlaylistsFromRedis(mockMember.id)).thenReturn(likedPlaylists)
+        whenever(playlistService.getLikedPlaylistsFromRedis(mockMember.id!!)).thenReturn(likedPlaylists)
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/playlists/liked"))


### PR DESCRIPTION
## 개요

1. 회원 조회 실패 Exception 중복 최소화
회원 ID가 null일 수도 있고,
DB에 존재하지 않을 수도 있는 두 가지 예외 상황의 책임을
Repository 확장 함수에서 처리하도록 위임

2. Member Id val 변화 및 생성자 정리

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 생성자 정리
- [ ] change Member.id from var to val
- [ ] Repository 회원 조회 예외 책임 위임